### PR TITLE
 **##fix<feature/footer => Develop>:**  style fixes in the footer for mobile and tablet, both are already 100%

### DIFF
--- a/styles/css/global/footer/footer-mobile/vtex.flex-layout.css
+++ b/styles/css/global/footer/footer-mobile/vtex.flex-layout.css
@@ -9,7 +9,7 @@
   flex-direction: row;
   width: 12.6875rem !important;
   justify-content: flex-start;
-  background-color: #3f3f40;
+  background-color: #3c3c42;
   cursor: pointer;
 
 }
@@ -24,4 +24,16 @@
 
 .flexColChild--footer__mobile--colombia {
   margin-right: 1rem;
+}
+
+@media (min-width: 320px) and (max-width: 480px) {
+  
+.flexCol--footer__section2--col2{
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+  .flexColChild--footer__section2--col3{
+    height: 48px !important;
+  }
 }

--- a/styles/css/global/footer/footer-mobile/vtex.rich-text.css
+++ b/styles/css/global/footer/footer-mobile/vtex.rich-text.css
@@ -9,3 +9,18 @@
     color: #FFF;
     font-size: 12px;
 }
+
+.link--footer__desktopCol--text{
+    text-decoration: none;
+    color: #83838f;
+}
+
+@media (min-width: 320px) and (max-width: 480px) {
+  .paragraph--footer__desktopCol--text--link{
+    text-align: center;
+  }
+  .paragraph--footer__desktopCol--text{
+    text-align: center;
+  }
+  
+}

--- a/styles/css/global/footer/footer-mobile/vtex.store-footer.css
+++ b/styles/css/global/footer/footer-mobile/vtex.store-footer.css
@@ -1,0 +1,6 @@
+@media (min-width: 320px) and (max-width: 480px) {
+  .poweredBy{
+    margin-bottom: 2.5rem !important;
+    transform: translate(164px, 30px);
+  }
+}

--- a/styles/css/tablet/footer/footer-fqa/vtex.flex-layout.css
+++ b/styles/css/tablet/footer/footer-fqa/vtex.flex-layout.css
@@ -1,0 +1,24 @@
+@media (min-width: 768px) and (max-width: 1024px) {
+  
+  .flexRowContent--Container__social-media-block{
+    padding: 1rem;
+    position: relative;
+  }
+
+  .flexCol--footer__mobile--colombia  {
+    display: flex;
+    justify-content: flex-start;
+    height: 2.7125rem;
+    position: absolute;
+    top: -32px;
+    left: 38%;
+  }
+
+  .flexColChild--footer__section2--col3 {
+    transform: translate(10px, 38px);
+  }
+
+  .flexColChild--footer__mobile--columns:first-child{
+    padding-top: 1.5rem;
+  }
+}

--- a/styles/css/tablet/footer/footer-fqa/vtex.rich-text.css
+++ b/styles/css/tablet/footer/footer-fqa/vtex.rich-text.css
@@ -1,0 +1,6 @@
+@media (min-width: 768px) and (max-width: 1024px) {
+  .paragraph--footer__section2--text{
+    width: 7.375rem;
+    transform: translate(-80px,49px);
+  }
+}


### PR DESCRIPTION
positioning fix in the footer, both for mobile and tablet.

**Sesult for mobile**
![mobile (4)](https://user-images.githubusercontent.com/99746056/215255073-8086dbfc-8133-4d01-9fce-66ca5061f7b2.gif)

**result for tablet**

![mobile (5)](https://user-images.githubusercontent.com/99746056/215255086-14b6ad23-b18a-41e3-b92a-cbea4c5a9e42.gif)
