### PR TITLE
##feat<feature/bullet-group-Develop>: Completion of the bullet group component

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,8 @@
     "vtex.styleguide": "9.x",
     "vtex.tab-layout": "0.x",
     "vtex.telemarketing": "2.x",
-    "itgloberspartnercl.whatsapp-button": "0.x"
+    "itgloberspartnercl.whatsapp-button": "0.x",
+    "itgloberspartnercl.bullets-diagramation": "0.x"
   },
   "peerDependencies": {
     "vtex.wish-list": "1.x",

--- a/store/blocks/desktop/screen/home.jsonc
+++ b/store/blocks/desktop/screen/home.jsonc
@@ -9,6 +9,7 @@
       "flex-layout.row#container__drawer",
       "flex-layout.row#home__rich--text",
       "flex-layout.row#home__pictures",
+      "list-context.bullet-group",
       "flex-layout.row#product__list--text",
       "flex-layout.row#product__list--context",
       "rich-text#home__favorites--store",

--- a/store/blocks/desktop/screen/home.jsonc
+++ b/store/blocks/desktop/screen/home.jsonc
@@ -9,7 +9,7 @@
       "flex-layout.row#container__drawer",
       "flex-layout.row#home__rich--text",
       "flex-layout.row#home__pictures",
-      "list-context.bullet-group",
+      "flex-layout.row#bullets__group--list",
       "flex-layout.row#product__list--text",
       "flex-layout.row#product__list--context",
       "rich-text#home__favorites--store",

--- a/store/blocks/global/components/bulletGroup/bullet-container.jsonc
+++ b/store/blocks/global/components/bulletGroup/bullet-container.jsonc
@@ -1,0 +1,14 @@
+{
+  "flex-layout.row#bullets__group--list": {
+    "title": "Bullet Group",
+    "children": [
+      "flex-layout.col#bullets__group--text",
+      "list-context.bullet-group"
+    ],
+    "props": {
+      "horizontalAlign": "center",
+      "colSizing": "auto",
+      "blockClass": "bullet-group--list"
+    }
+  }
+}

--- a/store/blocks/global/components/bulletGroup/bullet-offers.jsonc
+++ b/store/blocks/global/components/bulletGroup/bullet-offers.jsonc
@@ -1,0 +1,32 @@
+{
+  "flex-layout.col#bullets__group--text": {
+    "title": "Bullet Group Text",
+    "children": [
+      "rich-text#bullets__group1",
+      "rich-text#bullets__group2"
+    ],
+    "props": {
+      "blockClass": "bullet__group--col"
+    }
+  },
+
+  "rich-text#bullets__group1": {
+    "title": "Bullet Text 1",
+    "props": {
+      "text": "OFERTAS QUE NO TE PUEDES PERDER",
+      "textAlignment": "CENTER",
+      "textPosition": "CENTER",
+      "blockClass": "bullet__group--text1"
+    }
+  },
+
+  "rich-text#bullets__group2": {
+    "title": "Bullet Text 2",
+    "props": {
+      "text": "Precios especiales por tiempo limitado.",
+      "textAlignment": "CENTER",
+      "textPosition": "CENTER",
+      "blockClass": "bullet__group--text2"
+    }
+  }
+}

--- a/store/blocks/global/components/bulletGroup/bullets-group.jsonc
+++ b/store/blocks/global/components/bulletGroup/bullets-group.jsonc
@@ -1,135 +1,191 @@
 {
   "list-context.bullet-group": {
+    "title": "List Context Bullets Group",
     "children": [
       "slider-layout#bullet-group"
     ],
     "props": {
       "bullets": [
         {
+          "imageAudio": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675884851/audio_bca8qr.png",
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675880251/discount1_lqerjf.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/355311/01-Product-WH-1000XM5-S.jpg?v=1762194157",
           "titleBullet": "Audífonos inalámbricos con noise cancelling WH-1000XM5",
+          "bulletBrand": "WH1000XM5/BMUC",
+          "bulletPrice": "$ 1.499.900",
+          "bulletDiscount": "$ 2.249.900",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675882509/2.0_un7hm1.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/355266/01-Product-SRS-XE200-D.jpg?v=1762162478",
           "titleBullet": "Parlante inalámbrico portátil XE200 de la serie X",
+          "bulletBrand": "SRS-XE200/HCLA",
+          "bulletPrice": "$ 498.999",
+          "bulletDiscount": "$ 699.000",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageAudio": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675884851/audio_bca8qr.png",
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675882522/3.0_ok1yac.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/351282/d7b7a583061ec800dfa74bea7bc37941.jpg?v=1762162480",
           "titleBullet": "Audífonos inalámbricos con Noise Cancelling WF-1000XM4",
+          "bulletBrand": "WF1000XM4/BMUC",
+          "bulletPrice": "$ 899.898",
+          "bulletDiscount": "$ 1.499.900",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675882532/4.0_xrubwm.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/350957/KD-65X80J-1.jpg?v=1762162479",
           "titleBullet": "X80J | 4K Ultra HD | Alto rango dinámico (HDR) | Smart TV (Google TV)",
+          "bulletBrand": "|KD-65X80J",
+          "bulletPrice": "$ 4.299.893",
+          "bulletDiscount": "$ 6.499.999",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675882539/40_twokt8.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352284/e6c64548ff9844b62832b1816a1aa3a4.jpg?v=1762162483",
           "titleBullet": "Parlante inalámbrico portátil XP500 de la serie X",
+          "bulletBrand": "SRS-XP500/BCLA9",
+          "bulletPrice": "$ 1.299.000",
+          "bulletDiscount": "$ 2.149.000",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675883191/trh_ejlmub.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352891/6ff70f66ce935f02861635b3e936a70c.jpg?v=1762193861",
           "titleBullet": "Audífonos True Wireless WF-C500",
+          "bulletBrand": "WF-C500/WZ UC",
+          "bulletPrice": "$ 299.779",
+          "bulletDiscount": "$ 549.900",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675882556/38_prgqmh.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/355337/SRS-XG300B.jpg?v=1762162477",
           "titleBullet": "Parlante inalámbrico portátil XG300 de la serie X",
+          "bulletBrand": "SRS-XG300/BCLA7",
+          "bulletPrice": "$ 998.999",
+          "bulletDiscount": "$ 1.599.003",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageAudio": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675884851/audio_bca8qr.png",
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675883538/39_zexw2d.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352217/WH1000XM4_Black---1-.jpg?v=1762161213",
           "titleBullet": "Audífonos inalámbricos con noise cancelling WH1000XM4",
+          "bulletBrand": "WH1000XM4BMUC",
+          "bulletPrice": "$ 1.106.010",
+          "bulletDiscount": "$ 1.809.902",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675883538/39_zexw2d.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/355702/01-Product-WF-LS900-L-ALT.jpg?v=1762188677",
           "titleBullet": "Audífonos inalámbricos con cancelación de ruido LinkBuds S | WF-LS900N",
+          "bulletBrand": "WF-LS900N/BCUC",
+          "bulletPrice": "$ 690.469",
+          "bulletDiscount": "$ 1.129.900",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675882564/36_nchrhh.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352275/6364a26f0350572e348f7a7851ddc755.jpg?v=1762162484",
           "titleBullet": "Parlante inalámbrico portátil XP700 de la serie X",
+          "bulletBrand": "SRS-XP700/BCLA9",
+          "bulletPrice": "$ 1.798.996",
+          "bulletDiscount": "$ 2.799.004",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675882576/32_mubw0h.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/354964/7fc14e756300807519fde2f4c9996b9f.jpg?v=1762162476",
           "titleBullet": "Barra de sonido de 2.1 canales con potente subwoofer inalámbrico | HT-S400",
+          "bulletBrand": "HT-S400//C  LA9",
+          "bulletPrice": "$ 893.464",
+          "bulletDiscount": "$ 1.319.990",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675883753/39-exclusive_p98p0w.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/350345/ee8ccc400849734aa981fc0d9e5dc3f2.jpg?v=1762185067",
           "titleBullet": "Parlante inalámbrico premium SRS-RA3000 con sonido ambiental que llena la habitación",
+          "bulletBrand": "SRS-RA3000BMLA9",
+          "bulletPrice": "$ 1.099.898",
+          "bulletDiscount": "$ 1.799.000",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675883863/31_nzlvh5.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/339272/1a26f75f6bc8b7d417e77a6edb85a8c1.jpg?v=1762162486",
           "titleBullet": "Sistema de audio de alta potencia V13 con tecnología BLUETOOTH®",
+          "bulletBrand": "MHC-V13//M LA9",
+          "bulletPrice": "$ 1.149.898",
+          "bulletDiscount": "$ 1.669.000",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675882569/three_hixpmi.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/189026/b2a6c0f0b3136f302df64ef870c62f1e.jpg?v=1762162486",
           "titleBullet": "Tocadiscos con conectividad BLUETOOTH®",
+          "bulletBrand": "PS-LX310BT/CLA9",
+          "bulletPrice": "$ 999.898",
+          "bulletDiscount": "$ 1.199.900",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675884006/30_qkjave.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/340412/4dfd9ca48ba82b26b620b9049c099665.jpg?v=1762162477",
           "titleBullet": "X80H | 4K Ultra HD | Alto rango dinámico (HDR) | Smart TV (Android TV)",
+          "bulletBrand": "XBR-85X807H CO1",
+          "bulletPrice": "$ 9.389.887",
+          "bulletDiscount": "$ 13.349.000",
           "link": {
             "url": "/"
           }
         },
         {
+          "imageDiscount": "https://res.cloudinary.com/dafsjo7al/image/upload/v1675884075/26_zhldhm.png",
           "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352866/bbe592b986fba7179121a5e8c0017a1d.jpg?v=1762162478",
           "titleBullet": "Parlante inalámbrico portátil EXTRA BASS™ XB13",
+          "bulletBrand": "SRS-XB13/LC LA",
+          "bulletPrice": "$ 199.900",
+          "bulletDiscount": "$ 269.900",
           "link": {
             "url": "/"
           }
         }
       ]
-    }
-  },
-  "slider-layout#bullet-group": {
-    "props": {
-      "itemsPerPage": {
-        "desktop": 4,
-        "tablet": 3,
-        "phone": 3
-      },
-      "infinite": true,
-      "blockClass": "slider__bullet",
-      "showPaginationDots": "never"
     }
   }
 }

--- a/store/blocks/global/components/bulletGroup/bullets-group.jsonc
+++ b/store/blocks/global/components/bulletGroup/bullets-group.jsonc
@@ -1,0 +1,135 @@
+{
+  "list-context.bullet-group": {
+    "children": [
+      "slider-layout#bullet-group"
+    ],
+    "props": {
+      "bullets": [
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/355311/01-Product-WH-1000XM5-S.jpg?v=1762194157",
+          "titleBullet": "Audífonos inalámbricos con noise cancelling WH-1000XM5",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/355266/01-Product-SRS-XE200-D.jpg?v=1762162478",
+          "titleBullet": "Parlante inalámbrico portátil XE200 de la serie X",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/351282/d7b7a583061ec800dfa74bea7bc37941.jpg?v=1762162480",
+          "titleBullet": "Audífonos inalámbricos con Noise Cancelling WF-1000XM4",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/350957/KD-65X80J-1.jpg?v=1762162479",
+          "titleBullet": "X80J | 4K Ultra HD | Alto rango dinámico (HDR) | Smart TV (Google TV)",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352284/e6c64548ff9844b62832b1816a1aa3a4.jpg?v=1762162483",
+          "titleBullet": "Parlante inalámbrico portátil XP500 de la serie X",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352891/6ff70f66ce935f02861635b3e936a70c.jpg?v=1762193861",
+          "titleBullet": "Audífonos True Wireless WF-C500",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/355337/SRS-XG300B.jpg?v=1762162477",
+          "titleBullet": "Parlante inalámbrico portátil XG300 de la serie X",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352217/WH1000XM4_Black---1-.jpg?v=1762161213",
+          "titleBullet": "Audífonos inalámbricos con noise cancelling WH1000XM4",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/355702/01-Product-WF-LS900-L-ALT.jpg?v=1762188677",
+          "titleBullet": "Audífonos inalámbricos con cancelación de ruido LinkBuds S | WF-LS900N",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352275/6364a26f0350572e348f7a7851ddc755.jpg?v=1762162484",
+          "titleBullet": "Parlante inalámbrico portátil XP700 de la serie X",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/354964/7fc14e756300807519fde2f4c9996b9f.jpg?v=1762162476",
+          "titleBullet": "Barra de sonido de 2.1 canales con potente subwoofer inalámbrico | HT-S400",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/350345/ee8ccc400849734aa981fc0d9e5dc3f2.jpg?v=1762185067",
+          "titleBullet": "Parlante inalámbrico premium SRS-RA3000 con sonido ambiental que llena la habitación",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/339272/1a26f75f6bc8b7d417e77a6edb85a8c1.jpg?v=1762162486",
+          "titleBullet": "Sistema de audio de alta potencia V13 con tecnología BLUETOOTH®",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/189026/b2a6c0f0b3136f302df64ef870c62f1e.jpg?v=1762162486",
+          "titleBullet": "Tocadiscos con conectividad BLUETOOTH®",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/340412/4dfd9ca48ba82b26b620b9049c099665.jpg?v=1762162477",
+          "titleBullet": "X80H | 4K Ultra HD | Alto rango dinámico (HDR) | Smart TV (Android TV)",
+          "link": {
+            "url": "/"
+          }
+        },
+        {
+          "image": "https://cosonyb2c.vtexassets.com/arquivos/ids/352866/bbe592b986fba7179121a5e8c0017a1d.jpg?v=1762162478",
+          "titleBullet": "Parlante inalámbrico portátil EXTRA BASS™ XB13",
+          "link": {
+            "url": "/"
+          }
+        }
+      ]
+    }
+  },
+  "slider-layout#bullet-group": {
+    "props": {
+      "itemsPerPage": {
+        "desktop": 4,
+        "tablet": 3,
+        "phone": 3
+      },
+      "infinite": true,
+      "blockClass": "slider__bullet",
+      "showPaginationDots": "never"
+    }
+  }
+}

--- a/store/blocks/global/components/bulletGroup/slider-bullets.jsonc
+++ b/store/blocks/global/components/bulletGroup/slider-bullets.jsonc
@@ -1,0 +1,15 @@
+{
+  "slider-layout#bullet-group": {
+    "title": "Slider bullet group",
+    "props": {
+      "itemsPerPage": {
+        "desktop": 4,
+        "tablet": 2,
+        "phone": 2
+      },
+      "infinite": true,
+      "blockClass": "slider__bullet",
+      "showPaginationDots": "mobileOnly"
+    }
+  }
+}

--- a/store/blocks/mobile/screen/home.jsonc
+++ b/store/blocks/mobile/screen/home.jsonc
@@ -10,6 +10,7 @@
       "flex-layout.row#mobile__home--slider2",
       "flex-layout.row#home__rich--text",
       "flex-layout.row#mobile__home--slider3",
+      "list-context.bullet-group",
       "flex-layout.row#product__list--text",
       "flex-layout.row#product__list--context",
       "flex-layout.row#home__rich--favorites",

--- a/store/blocks/mobile/screen/home.jsonc
+++ b/store/blocks/mobile/screen/home.jsonc
@@ -10,7 +10,7 @@
       "flex-layout.row#mobile__home--slider2",
       "flex-layout.row#home__rich--text",
       "flex-layout.row#mobile__home--slider3",
-      "list-context.bullet-group",
+      "flex-layout.row#bullets__group--list",
       "flex-layout.row#product__list--text",
       "flex-layout.row#product__list--context",
       "flex-layout.row#home__rich--favorites",

--- a/styles/configs/style.json
+++ b/styles/configs/style.json
@@ -81,11 +81,11 @@
     "background": {
       "header--background" : "#000",
       "header--search" : "##4472ED",
-      "price--product" : "##F25529", 
-      "new--product" : "##00CC6F", 
-      "product--discount" : "##A500AA", 
-      "exclusive--product" : "##006CC4", 
-      "product--warranty" : "##ABB2B9", 
+      "price--product" : "##F25529",
+      "new--product" : "##00CC6F",
+      "product--discount" : "##A500AA",
+      "exclusive--product" : "##006CC4",
+      "product--warranty" : "##ABB2B9",
       "latest offers"  : "##EF293E"
     },
     "hover-background": {

--- a/styles/css/global/bulletGroup/itgloberspartnercl.bullets-diagramation.css
+++ b/styles/css/global/bulletGroup/itgloberspartnercl.bullets-diagramation.css
@@ -1,0 +1,20 @@
+.bullet__item--title{
+  font-size: 13px;
+  line-height: 18px;
+  color: #2f353d;
+  overflow-wrap: break-word;
+  font-weight: 400;
+  height: 37px;
+}
+
+
+
+/* @media screen and (max-width:760px){
+  .bullet__item{
+
+  }
+
+  .bullet__item--image{
+
+  }
+} */

--- a/styles/css/global/bulletGroup/vtex.flex-layout.css
+++ b/styles/css/global/bulletGroup/vtex.flex-layout.css
@@ -1,0 +1,21 @@
+.flexRow--bullet-group--list{
+  padding: 3rem;
+  border-top: 1px solid #e3e4e6;
+  border-bottom: 1px solid #e3e4e6;
+}
+
+.flexRowContent--bullet-group--list{
+    display: flex;
+    flex-direction: column;
+}
+
+.flexCol--bullet__group--col{
+  margin-bottom: 2rem;
+}
+
+@media only screen and (max-width: 575px){
+  .flexRow--bullet-group--list{
+  padding: 0px !important;
+}
+
+}

--- a/styles/css/global/bulletGroup/vtex.rich-text.css
+++ b/styles/css/global/bulletGroup/vtex.rich-text.css
@@ -1,0 +1,14 @@
+.wrapper--bullet__group--text1{
+    font-size: 22px;
+    color: #2f353d;
+    font-weight: 700;
+    line-height: 24px;
+}
+
+.wrapper--bullet__group--text2{
+  font-size: 18px;
+  color: #83838f;
+  line-height: 20px;
+  margin-top: 10px;
+
+}

--- a/styles/css/global/bulletGroup/vtex.slider-layout.css
+++ b/styles/css/global/bulletGroup/vtex.slider-layout.css
@@ -2,22 +2,18 @@
   font-size: 13px;
   line-height: 18px;
   color: #2f353d;
-  overflow-wrap: break-word;
   font-weight: 400;
-  height: 37px;
+  overflow-wrap: break-word;
 }
 
 .bullet__item{
   width: 18rem;
   margin-right: .9375rem;
 }
-.bullet__item:hover{
-  border: solid 1px rgba(230, 228, 228, 0.959);
-}
 .bullet__item--image{
   width: 100%;
+  height: 17.9375rem;
 }
-
 .bullet__item--image:hover{
   filter: opacity(.5);
 }
@@ -25,16 +21,102 @@
   text-decoration: none;
 }
 
-
-.bullet__item--slider__bullet{
-  border : 1px solid red
-}
-
-.lideChildrenContainer--slider__bullet{
-  border: 1px solid orange;
-}
-
 .sliderLayoutContainer--slider__bullet{
   max-width: 1196px;
   margin: 0 auto;
+}
+
+.sliderArrows--slider__bullet{
+  cursor: pointer;
+  z-index: 2;
+  width: 32px;
+  height: 52px;
+  background-color: rgba(56, 55, 55, 0.404) !important;
+  color: #fff;
+  border-radius: 3px;
+  transition: all .25s;
+  margin: -2rem;
+}
+
+.slideChildrenContainer--slider__bullet:hover{
+  border: solid 1px rgba(230, 228, 228, 0.959);
+}
+
+.bullet__item--discount--slider__bullet{
+    position: absolute;
+    top: 8px;
+    right: 7px;
+    z-index: 2;
+}
+
+.bullet__item--audio--slider__bullet{
+  transform: translateY(6px);
+  z-index: 2;
+}
+.bullet__item--brand--slider__bullet{
+  font-size: 11px;
+  color: #83838f;
+  margin-bottom: 0.2em;
+}
+.bullet__item--price--slider__bullet{
+  font-size: 16px;
+  font-weight: 700;
+  color: #f25529;
+  margin-top: 10px;
+}
+.bullet__discount--text--slider__bullet{
+  font-size: 12px;
+  color: #83838f;
+  text-decoration: line-through;
+  font-weight: 400;
+}
+
+
+/* MOBILE */
+
+@media only screen and (max-width: 575px){
+    .bullet__item--link{
+  text-decoration: none;
+}
+.paginationDotsContainer--slider__bullet{
+  transform: translateY(37px);
+}
+.paginationDot--slider__bullet--isActive{
+    background-color: #575757;
+}
+.sliderArrows--slider__bullet{
+  width: 32px;
+  height: 52px;
+  margin: 0px !important;
+}
+.bullet__item{
+  width: 18rem;
+  height: 15rem;
+  margin-right: .9375rem;
+}
+.bullet__item--image{
+  width: 100%;
+  height: 13.9375rem;
+}
+.slideChildrenContainer--slider__bullet{
+  height: 26.125rem;
+  align-items: start;
+}
+
+}
+
+
+/* TABLET */
+
+@media only screen and (min-width: 768px) and (max-width: 991px){
+  .sliderArrows--slider__bullet{
+    margin: 0px !important;
+}
+.paginationDot--slider__bullet--isActive{
+      background-color: #575757;
+}
+.paginationDotsContainer--slider__bullet{
+  transform: translateY(30px);
+}
+
 }

--- a/styles/css/global/bulletGroup/vtex.slider-layout.css
+++ b/styles/css/global/bulletGroup/vtex.slider-layout.css
@@ -1,0 +1,40 @@
+.bullet__item--title{
+  font-size: 13px;
+  line-height: 18px;
+  color: #2f353d;
+  overflow-wrap: break-word;
+  font-weight: 400;
+  height: 37px;
+}
+
+.bullet__item{
+  width: 18rem;
+  margin-right: .9375rem;
+}
+.bullet__item:hover{
+  border: solid 1px rgba(230, 228, 228, 0.959);
+}
+.bullet__item--image{
+  width: 100%;
+}
+
+.bullet__item--image:hover{
+  filter: opacity(.5);
+}
+.bullet__item--link{
+  text-decoration: none;
+}
+
+
+.bullet__item--slider__bullet{
+  border : 1px solid red
+}
+
+.lideChildrenContainer--slider__bullet{
+  border: 1px solid orange;
+}
+
+.sliderLayoutContainer--slider__bullet{
+  max-width: 1196px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
|--> description: Added custom bullet group component to the store
|--> How to test it?: tests were made of the responsive views both on mobile and tablet [Workspace](https://sebastiandev--itgloberspartnercl.myvtex.com/)
|--> How does this PR make you feel?: very good😀
|--> #### Screenshots or example usage:

**Desktop view**
![bullets-group](https://user-images.githubusercontent.com/99746056/217680541-1befe536-ae27-4ef0-94b3-124c23233750.png)
 **Mobile  view** 
![mobile--bullet](https://user-images.githubusercontent.com/99746056/217680553-ceb93539-582a-4ff0-811a-7269f35e0bd4.png)
**Tablet view**
![tablet-bullet](https://user-images.githubusercontent.com/99746056/217680563-707ea142-691d-4656-bc71-f95168f05432.png)

|--> Does it depend on another component?: Yes   
the bullet-group component, here the repository https://github.com/SebastianHinestroza12/itgloberspartnercl-bullets-diagramation
|--> name-element-additional: 
It shows us a list of products, with their image, title and prices